### PR TITLE
Changes JSON library version to latest pinned version on Share

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=download /usr/local/bin/ucm /usr/local/bin/ucm
 # Setting this environment variable directs the UCM config to a writeable directory
 ENV XDG_DATA_HOME=/tmp
 RUN /usr/local/bin/ucm --no-base -C /opt/test-runner/tmp/testRunner
-RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY --from=download /usr/local/bin/ucm /usr/local/bin/ucm
 # Setting this environment variable directs the UCM config to a writeable directory
 ENV XDG_DATA_HOME=/tmp
 RUN /usr/local/bin/ucm --no-base -C /opt/test-runner/tmp/testRunner
-RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
-RUN echo "pull stew.public.projects.json.releases.v3 lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=download /usr/local/bin/ucm /usr/local/bin/ucm
 # Setting this environment variable directs the UCM config to a writeable directory
 ENV XDG_DATA_HOME=/tmp
 RUN /usr/local/bin/ucm --no-base -C /opt/test-runner/tmp/testRunner
-RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner

--- a/DockerfileMac
+++ b/DockerfileMac
@@ -10,8 +10,8 @@ COPY unison-arm/unison /usr/local/bin/ucm
 
 RUN chmod +x /usr/local/bin/ucm
 ENV XDG_DATA_HOME=/tmp
-RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
-RUN echo "pull stew.public.projects.json.releases.v3 lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
+RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/DockerfileMac
+++ b/DockerfileMac
@@ -10,7 +10,7 @@ COPY unison-arm/unison /usr/local/bin/ucm
 
 RUN chmod +x /usr/local/bin/ucm
 ENV XDG_DATA_HOME=/tmp
-RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
 RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner

--- a/DockerfileMac
+++ b/DockerfileMac
@@ -10,7 +10,7 @@ COPY unison-arm/unison /usr/local/bin/ucm
 
 RUN chmod +x /usr/local/bin/ucm
 ENV XDG_DATA_HOME=/tmp
-RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.base.latest .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
 RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner

--- a/src/errorMain.u
+++ b/src/errorMain.u
@@ -2,25 +2,25 @@
 {{{errorStatus.main} is the entry point function for the case where the student submits non-compiling code, resulting in the results.json file not being written with failing test data. This script should be run in the event that the results file failed to be created. It parses the transcript error output and creates a json file.}}
 errorStatus.main : '{IO,Exception}()
 errorStatus.main _ =
-  solutionsDir = io.getEnv "solution_dir"
+  solutionsDir = IO.getEnv "solution_dir"
   transcriptFailure = FilePath (solutionsDir ++ "/.meta/testLoader.output.md" )
   transcriptOutput = readFile transcriptFailure
   messageBody = errorStatus.getTranscriptError transcriptOutput
   json = toTestFile messageBody |> toJson
   jsonString = json |> compactSpecial
-  envFilePath = io.getEnv "results_file"
+  envFilePath = IO.getEnv "results_file"
   filePath = FilePath ( envFilePath )
   writeFile filePath jsonString
 
 writeFile : FilePath -> Text ->{IO, Exception} ()
 writeFile path content =
   fileHandle : '{IO, Exception} Handle
-  fileHandle _ = openFile path Write
-  bracket fileHandle closeFile (h -> putBytes h (toUtf8 content))
+  fileHandle _ = FilePath.open path Write
+  bracket fileHandle Handle.close (h -> putBytes h (toUtf8 content))
 
 readFile : FilePath ->{IO, Exception} Text
 readFile path =
-  if not (base.io.fileExists path) then raise (failure "file not found" path) else
+  if not (FilePath.exists path) then raise (failure "file not found" path) else
     read : Handle ->{IO, Exception} Bytes
     read fileHandle =
       go acc =
@@ -30,8 +30,8 @@ readFile path =
         if Bytes.size bs < 4096 then acc ++ bs else go (acc ++ bs)
       go Bytes.empty
     fileHandle : '{IO, Exception} Handle
-    fileHandle _ = openFile path Read
-    bracket fileHandle closeFile (file -> read file |> fromUtf8)
+    fileHandle _ = FilePath.open path Read
+    bracket fileHandle Handle.close (file -> read file |> fromUtf8)
 
 {{
   {toTestFile} transforms the failed transcript message into the {type TestFile} data type.

--- a/src/fileModel.u
+++ b/src/fileModel.u
@@ -166,11 +166,6 @@ testRunner.TestAnnotation.fromJsonRead = 'let
 
   TestAnnotation (Name name) (TestCode testCode) taskId
 
-parser.Error.toFailure : parser.Error Unit JsonToken -> Failure
-parser.Error.toFailure error =
-  Failure (typeLink parser.Error) "A json parsing error occured" (Any error)
-
-
 {{We need these as addendum because the current JSON library doesn't escape a few control characters.
 
 It can be removed when the JSON library on Share has been updated
@@ -202,7 +197,7 @@ json.render.compactSpecial : Json -> Text
 json.render.compactSpecial = cases
   JNull       -> "null"
   JBoolean b  -> if b then "true" else "false"
-  JNumber f   -> number f
+  JNumber f   -> render.number f
   JString t   -> render.stringSpecial t
   JArray js   ->
     use Text ++

--- a/src/testMain.u
+++ b/src/testMain.u
@@ -11,13 +11,13 @@ use testRunner TestFile Test
 }}
 testRunner.main : '{IO,Exception}()
 testRunner.main _ =
-  solutionPrefix = io.getEnv "solution_dir"
+  solutionPrefix = IO.getEnv "solution_dir"
   testAnnotationFilePath = FilePath (solutionPrefix Text.++ "/.meta/testAnnotation.json")
   annotations = !(parseAnnotationFile testAnnotationFilePath)
   testRunner.checkAnnotationFile annotations tests
   json = toV2TestFile tests annotations |> toJson
   jsonString = json |> compactSpecial
-  envFilePath = io.getEnv "results_file"
+  envFilePath = IO.getEnv "results_file"
   filePath = FilePath ( envFilePath )
   writeFile filePath jsonString
 
@@ -59,12 +59,12 @@ testRunner.parseAnnotationFile testFilePath _ =
 testRunner.writeFile : FilePath -> Text ->{IO, Exception} ()
 testRunner.writeFile path content =
   fileHandle : '{IO, Exception} Handle
-  fileHandle _ = openFile path Write
-  bracket fileHandle closeFile (h -> putBytes h (toUtf8 content))
+  fileHandle _ = FilePath.open path Write
+  bracket fileHandle Handle.close (h -> putBytes h (toUtf8 content))
 
 testRunner.readFile : FilePath ->{IO, Exception} Text
 testRunner.readFile path =
-  if not (base.io.fileExists path) then raise (failure "file not found" path) else
+  if not (IO.FilePath.exists path) then raise (failure "file not found" path) else
     read : Handle ->{IO, Exception} Bytes
     read fileHandle =
       go acc =
@@ -74,6 +74,6 @@ testRunner.readFile path =
         if Bytes.size bs < 4096 then acc ++ bs else go (acc ++ bs)
       go Bytes.empty
     fileHandle : '{IO, Exception} Handle
-    fileHandle _ = openFile path Read
-    bracket fileHandle closeFile (file -> read file |> fromUtf8)
+    fileHandle _ = FilePath.open path Read
+    bracket fileHandle Handle.close (file -> read file |> fromUtf8)
 


### PR DESCRIPTION
This PR fixes an issue that some community members had mentioned in our slack where the tests couldn't find the `Parser` irrespective of their locally passing code. As it turns out, this was because of a missing link from our package repository. 
It also pins the base version to match function names referenced in the collection of `.u` files for producing the results json file. Code changes here are a reflection of the changed json and base versions, no corresponding changes should be required for the track content. 