### PR TITLE
using special pinned versions and updated executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian as download
 
-ADD https://github.com/unisonweb/unison/releases/download/release%2FM4/ucm-linux.tar.gz /tmp/ucm-linux.tar.gz
+ADD https://github.com/unisonweb/unison/releases/download/release%2FM4e/ucm-linux.tar.gz /tmp/ucm-linux.tar.gz
 
 RUN tar -x -z -f /tmp/ucm-linux.tar.gz -C /usr/local/bin ./ucm
 
@@ -14,8 +14,8 @@ COPY --from=download /usr/local/bin/ucm /usr/local/bin/ucm
 # Setting this environment variable directs the UCM config to a writeable directory
 ENV XDG_DATA_HOME=/tmp
 RUN /usr/local/bin/ucm --no-base -C /opt/test-runner/tmp/testRunner
-RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
-RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.exercism_tooling.pinnedLibVersions.base .base" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.exercism_tooling.pinnedLibVersions.json lib.json" | /usr/local/bin/ucm -c /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/DockerfileMac
+++ b/DockerfileMac
@@ -10,8 +10,8 @@ COPY unison-arm/unison /usr/local/bin/ucm
 
 RUN chmod +x /usr/local/bin/ucm
 ENV XDG_DATA_HOME=/tmp
-RUN echo "pull unison.public.base.releases.M4d .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
-RUN echo "pull stew.public.projects.json.releases.v6 lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.exercism_tooling.pinnedLibVersions.base .base" | /usr/local/bin/ucm -C /opt/test-runner/tmp/testRunner
+RUN echo "pull unison.public.exercism_tooling.pinnedLibVersions.json lib.json" | /usr/local/bin/ucm --codebase /opt/test-runner/tmp/testRunner
 
 WORKDIR /opt/test-runner
 COPY . .


### PR DESCRIPTION
This PR updates the Unison Executable to the latest version, M4e and also uses a special repo with pinned versions for downloading the initial set of libraries needed to run the test-runner. This should prevent the issue we found last time where it's possible for library versions to get moved out from underneath the test-runner. 