### PR TITLE
Fix docker builds on Apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian as download
+FROM --platform=linux/amd64 debian as download
 
 ADD https://github.com/unisonweb/unison/releases/download/release%2FM4i/ucm-linux.tar.gz /tmp/ucm-linux.tar.gz
 
 RUN tar -x -z -f /tmp/ucm-linux.tar.gz -C /usr/local/bin ./ucm
 
-FROM debian
+FROM --platform=linux/amd64 debian
 RUN apt-get update && \
     apt-get -y install git less jq && \
     apt-get purge --auto-remove && \


### PR DESCRIPTION
Previously the main docker build didn't work properly on Apple silicon (M1, etc). I think that the issue was that the Dockerfile downloads an x86 ucm binary but Docker detects that the host is ARM, so it targets the wrong platform for the binary.

This resolves the immediate issue, but there are some loose ends:

- There is a `DockerfileMac` and some documentation about running on M1 that can probably just go away.
- When I run `./bin/run-tests-in-docker.sh` I see some errors, but the exit code is `0`. It's possible that the errors that I'm seeing are expected (testing the cases where the user has errors in their input), but I don't _think_ so. It looks like maybe `tests` is an ambiguous term that needs to be qualified.